### PR TITLE
Wire org instruction catalog through metadata layer and align MCP server name

### DIFF
--- a/.github/instructions/metadata.agents.instructions.md
+++ b/.github/instructions/metadata.agents.instructions.md
@@ -37,6 +37,18 @@ Standard required reads:
 4. Stack-specific instruction files for the work area (see Stack guardrails below)
 ```
 
+### 2a. Catalog via MCP (when available)
+
+Immediately after the Required reading list, insert the bootstrap snippet below verbatim. It tells MCP-capable agents to call the org catalog server when one is wired into the client/runner. The snippet is intentionally **conditional** — it reads as a no-op in a repo where no MCP server is configured, and activates cleanly once one is. Do not rephrase it to claim a server "is" configured (consumer-repo MCP wiring is a separate, in-progress rollout). Keep this byte-identical to the version in `metadata.copilot-instructions.instructions.md` (that file is the source-of-truth).
+
+````markdown
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+````
+
 ### 3. Stack guardrails
 
 Per-stack lists of which `standards.*` / `patterns.*` / `platform.*` / `shared.*` files apply to this repo. Pull from `.github-copilot/.github/copilot-instructions.md` and only include the layers this repo actually consumes (discovered via `terraform_remote_state` blocks, `<PackageReference>` entries, etc.).
@@ -140,3 +152,4 @@ See `.github-copilot/templates/AGENTS.md` for the canonical skeleton.
 - `metadata.copilot-instructions.instructions.md` — sister file for `.github/copilot-instructions.md`
 - `personal.working-preferences.instructions.md` — always-on git/branching/code-review rules
 - [agents.md](https://agents.md) — the cross-tool convention this file implements
+- `mcp-server/README.md` — MCP server install / wire-up / tool contract

--- a/.github/instructions/metadata.copilot-instructions.instructions.md
+++ b/.github/instructions/metadata.copilot-instructions.instructions.md
@@ -32,6 +32,24 @@ When the target repo is one of the portal settings consumers (`portal-web`, `por
 - No reintroduction of ad hoc namespace/property JSON parsing in runtime paths for migrated namespaces.
 - Compatibility-only status of `XtremeIdiots.Portal.ChatCommands.Abstractions.V1` and shim-removal gate requirements.
 
+## MCP catalog snippet
+
+Every generated `.github/copilot-instructions.md` **must include** the bootstrap snippet below, verbatim, as a top-level section. It tells MCP-capable agents (VS Code Copilot Chat, the GitHub Copilot coding agent, Copilot CLI, Claude Desktop, etc.) to call the org catalog server when one is wired into the client.
+
+The snippet is intentionally **conditional**: it reads as a no-op in a repo where no MCP server is configured, and activates cleanly once one is. Do not rephrase it to claim a server "is" configured — at the time of writing, consumer-repo MCP wiring (`.vscode/mcp.json`, `copilot-setup-steps.yml` install step, `.github/copilot/mcp_config.json`) is a separate, in-progress rollout.
+
+Use this exact text (this file is the source-of-truth; future wording changes flow through here and the parallel section in `metadata.agents.instructions.md`):
+
+````markdown
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+````
+
+See `mcp-server/README.md` in `frasermolyneux/.github-copilot` for the tool surface details, content-root resolution, and wire-up snippets per client.
+
 ## What to avoid
 
 - Generic advice ("write tests", "handle errors", "follow SOLID").

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -29,7 +29,7 @@ All snippets assume you have cloned and built the server somewhere on disk and s
 ```json
 {
   "servers": {
-    "gh-copilot": {
+    "frasermolyneux-copilot": {
       "command": "node",
       "args": ["${userHome}/code/.github-copilot/mcp-server/dist/index.js"],
       "env": {
@@ -47,7 +47,7 @@ Add a Copilot setup step that builds the server, then declare it in the agent's 
 `.github/workflows/copilot-setup-steps.yml`:
 
 ```yaml
-- name: Install gh-copilot MCP server
+- name: Install frasermolyneux-copilot MCP server
   shell: bash
   run: |
     git clone --depth 1 https://github.com/frasermolyneux/.github-copilot /tmp/gh-copilot
@@ -61,7 +61,7 @@ Add a Copilot setup step that builds the server, then declare it in the agent's 
 ```json
 {
   "mcpServers": {
-    "gh-copilot": {
+    "frasermolyneux-copilot": {
       "command": "node",
       "args": ["/tmp/gh-copilot/mcp-server/dist/index.js"],
       "env": {
@@ -77,7 +77,7 @@ Add a Copilot setup step that builds the server, then declare it in the agent's 
 ```json
 {
   "mcpServers": {
-    "gh-copilot": {
+    "frasermolyneux-copilot": {
       "command": "node",
       "args": ["/absolute/path/to/.github-copilot/mcp-server/dist/index.js"],
       "env": {
@@ -112,9 +112,9 @@ Each file is also exposed as an MCP resource, so clients that browse `resources/
 
 | Scheme | Example URI |
 |---|---|
-| `gh-copilot://instructions/{name}` | `gh-copilot://instructions/patterns.api-client` |
-| `gh-copilot://prompts/{name}` | `gh-copilot://prompts/update-build-and-test-workflow` |
-| `gh-copilot://agents/{name}` | `gh-copilot://agents/code-review` |
+| `frasermolyneux-copilot://instructions/{name}` | `frasermolyneux-copilot://instructions/patterns.api-client` |
+| `frasermolyneux-copilot://prompts/{name}` | `frasermolyneux-copilot://prompts/update-build-and-test-workflow` |
+| `frasermolyneux-copilot://agents/{name}` | `frasermolyneux-copilot://agents/code-review` |
 
 Resource bodies are the raw `.md` file (frontmatter included), MIME type `text/markdown`.
 
@@ -134,7 +134,7 @@ Drop the following into a consumer repo's `.github/copilot-instructions.md` so a
 ```markdown
 ## Org conventions via MCP
 
-A `gh-copilot` MCP server is configured for this repo. **Before answering questions
+A `frasermolyneux-copilot` MCP server is configured for this repo. **Before answering questions
 about org standards, branching, workflows, Terraform, .NET projects, or Azure
 patterns, call its tools** (`list_instructions`, `search_instructions`,
 `get_instruction`, plus the `_prompts` and `_agents` equivalents) and prefer

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -10,10 +10,10 @@ const SINGULAR: Record<Kind, string> = {
 };
 
 function registerKind(server: McpServer, kind: Kind): void {
-  const scheme = `gh-copilot://${kind}/`;
+  const scheme = `frasermolyneux-copilot://${kind}/`;
   server.registerResource(
     SINGULAR[kind],
-    new ResourceTemplate(`gh-copilot://${kind}/{name}`, {
+    new ResourceTemplate(`frasermolyneux-copilot://${kind}/{name}`, {
       list: async () => ({
         resources: listItems(kind).map((item) => ({
           uri: `${scheme}${item.name}`,

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -20,6 +20,14 @@ The `copilot-setup-steps.yml` workflow checks out `frasermolyneux/.github-copilo
 
 ---
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
+---
+
 ## Stack guardrails
 
 <!-- List only the layers this repo consumes. Discover via:


### PR DESCRIPTION
## Why

The `mcp-server/` catalog merged recently, but nothing in the metadata generation guidelines told the AI agents we generate `.github/copilot-instructions.md` and `AGENTS.md` for to actually call its tools. Without that nudge, the MCP server is dead weight to every consumer repo. This wires the bootstrap guidance through the metadata layer so it flows out to every repo on the next `update-project-metadata` run, and aligns the server's own identifier with the name now mandated by that guidance.

## What changed

Two coherent pieces on one branch:

**1. Bootstrap snippet rolled out through metadata (additive only)**

A single byte-identical snippet (1094 chars) is now defined in three places:

- `.github/instructions/metadata.copilot-instructions.instructions.md` — new `## MCP catalog snippet` section, designated as the source-of-truth for future wording changes.
- `.github/instructions/metadata.agents.instructions.md` — new `### 2a. Catalog via MCP (when available)` sub-section, plus `mcp-server/README.md` added to Cross-references.
- `templates/AGENTS.md` — new `## Org conventions via MCP (when available)` top-level section between Required reading and Stack guardrails.

The snippet is intentionally **conditional** ("If a `frasermolyneux-copilot` MCP server is configured in your client..."). It reads as a clean no-op in any consumer repo where MCP isn't wired up yet, and activates once one is. This matters because consumer-repo MCP wiring (`.vscode/mcp.json`, `copilot-setup-steps.yml` install step, `.github/copilot/mcp_config.json`) does not exist anywhere yet — it's a deliberate follow-up.

**2. MCP server identifier and resource URI scheme renamed to `frasermolyneux-copilot`**

`mcp-server/README.md` previously called the server `gh-copilot` in every client wire-up snippet and used `gh-copilot://` as the resource URI scheme. Renamed both to `frasermolyneux-copilot` / `frasermolyneux-copilot://` so the server's own contract matches the name the metadata layer now mandates. Touches:

- `mcp-server/README.md` — 5 server-identifier sites (L32, L50, L64, L80, L137) plus the 3 resource URI table rows (L115-117).
- `mcp-server/src/resources.ts` — the 2 `ResourceTemplate` literals (L13, L16) that define the URI scheme in code.

The bin command `gh-copilot-mcp` and the package name `frasermolyneux-copilot-mcp-server` were deliberately left alone — they're executable / package identifiers, not the MCP server-identity contract.

## Verification

- `npm run build` in `mcp-server/` succeeds clean (`tsc` no output).
- `npm run smoke` passes — server starts, content root resolves with `instructions=66 prompts=16 agents=6`, all 7 tools register, `list_instructions` returns 66 items.
- `git grep -F "gh-copilot://" mcp-server/` returns zero hits.
- Bootstrap snippet body verified byte-identical across all three metadata sites (same SHA256).
- `code-review` sub-agent run on the metadata edits caught one High issue (heading-level mismatch breaking byte-identity in `templates/AGENTS.md`) which was resolved before the URI scheme rename was added.

## Follow-ups (deliberate, not in this PR)

- Consumer-repo MCP wiring: `.vscode/mcp.json` for VS Code, MCP install step in `copilot-setup-steps.yml`, and `.github/copilot/mcp_config.json` for the GitHub Copilot coding agent. Likely per-repo via `align-project-workflows` or a dedicated prompt.
- Re-running `update-project-metadata` against each consumer repo to flush the new snippet into their `.github/copilot-instructions.md` and `AGENTS.md`.