### PR TITLE
docs(mcp-server): pin v0.1.0 in cloud-agent setup example

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -51,7 +51,7 @@ Add a Copilot setup step that builds the server, then declare it in the agent's 
 - name: Install frasermolyneux-copilot MCP server
   shell: bash
   run: |
-    git clone --depth 1 https://github.com/frasermolyneux/.github-copilot /tmp/gh-copilot
+    git clone --depth 1 --branch v0.1.0 https://github.com/frasermolyneux/.github-copilot /tmp/gh-copilot
     cd /tmp/gh-copilot/mcp-server
     npm ci
     npm run build
@@ -259,7 +259,7 @@ mcp-server/
 ## Caveats
 
 - **MCP clients don't auto-load catalog content.** Tools must be called explicitly. The bootstrap snippet above tells the agent to do that — without it, the agent will happily ignore the catalog.
-- **Pin a tag or commit SHA** in `copilot-setup-steps.yml` (`git clone --branch v0.1.0 …` or `git checkout <sha>` after clone). `main` will drift; pinning avoids surprise behavioural changes inside CI runs.
+- **The cloud-agent example above pins the `v0.1.0` tag.** `main` will drift; the pin avoids surprise behavioural changes inside CI runs. Bump the tag (or swap in a commit SHA via `git checkout <sha>` after clone) as new releases of `.github-copilot` ship.
 - **No `npx` / `github:` install path.** There is no root `package.json` in the catalog repo and no `prepare` script that builds the server post-install, so `npx github:frasermolyneux/.github-copilot` does not work. Use the clone + build path above until a published artifact exists.
 - **Cloud agent MCP support is evolving.** The wire-up above reflects the current `.github/copilot/mcp_config.json` convention. Re-check the [GitHub docs on Copilot coding agent MCP](https://docs.github.com/en/copilot) before relying on it for production workflows.
 - **No CI workflow ships with this server yet.** Build/lint/publish workflows for `mcp-server/` are a deliberate follow-up.


### PR DESCRIPTION
Now that `v0.1.0` is tagged on this repo and consumers (e.g. `portal-core`) have updated their `copilot-setup-steps.yml` to pin to it, the README's own example should match so a copy/paste yields a working, pinned wire-up rather than one that silently tracks `main`.

## Changes (single file: `mcp-server/README.md`)

- **Cloud-agent setup snippet (L54):** added `--branch v0.1.0` to the `git clone --depth 1 …` invocation in the `.github/workflows/copilot-setup-steps.yml` example.
- **Caveats bullet (L262):** reworded from "Pin a tag or commit SHA" (advice to do it) to "The example above pins the `v0.1.0` tag" (acknowledging it's already done), with a brief note on bumping the tag as new releases ship. The underlying "`main` will drift" point is preserved.

## Out of scope (intentionally untouched)

- L14 human dev-install clone (for working *on* the mcp-server itself) stays unpinned.
- `mcp_config.json` JSON snippets, user-level CLI / VS Code / App sections.

## Review note

Initial draft used `--branch refs/tags/v0.1.0`. The code-review sub-agent caught this as High severity: `git clone --branch` only accepts a short tag/branch name (the fully-qualified ref form is `actions/checkout`-only), so consumers would have hit `fatal: Remote branch refs/tags/v0.1.0 not found in upstream origin` on the first CI run. Fixed to `v0.1.0` short form and verified `git ls-remote --tags … v0.1.0` resolves cleanly against the live remote.