### PR TITLE
ci: add MCP Server CI workflow for mcp-server/

### DIFF
--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -1,0 +1,49 @@
+name: MCP Server CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - mcp-server/**
+      - .github/workflows/mcp-server-ci.yml
+  push:
+    branches:
+      - main
+    paths:
+      - mcp-server/**
+      - .github/workflows/mcp-server-ci.yml
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Smoke test
+        run: npm run smoke


### PR DESCRIPTION
## Summary

First CI workflow in this repo. Gates future `mcp-server/` tags (e.g. `v0.2.0`) by verifying `main` always builds and smoke-tests cleanly. After cutting `v0.1.0` the package was shipping with no CI safety net; this closes that gap.

## Type of change

- [x] ci (GitHub Actions / Dependabot)

## Required reading consulted

- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`workflows.instructions.md` — universal layer)

## Validation evidence

### Build

```text
N/A — no source changes in this PR. The workflow itself runs `npm ci && npm run build && npm run smoke` against `mcp-server/` on every future PR / push to main that touches `mcp-server/**`.
```

### Tests

```text
N/A — see Build.
```

### Format check

```text
python -c "import yaml; yaml.safe_load(open('.github/workflows/mcp-server-ci.yml'))" → YAML OK
```

### Other (lint, terraform plan summary, screenshots)

`code-review` sub-agent run against the new workflow — no High/Medium findings. Confirmed:

- Tag pins `@v6` on `actions/checkout` and `actions/setup-node` match `workflows.instructions.md`.
- `permissions: {}` top-level, `contents: read` on the job.
- PR-check concurrency: `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` with `cancel-in-progress: true`.
- `pull_request` types list is the exact canonical set.
- `push` scoped to `main`.
- `cache-dependency-path` is repo-root-relative — correct because `setup-node` runs from repo root, not from `defaults.run.working-directory`.

## Risk and rollout

- **Blast radius:** CI only. No Azure resources, no runtime code, no published packages affected.
- **Auto-deploys on merge?** No.
- **Manual steps post-merge:** None. The workflow becomes active on the next PR / push that touches `mcp-server/**` (or on manual `workflow_dispatch`).
- **Rollback plan:** Revert the single-file commit. No state to clean up.

## Consumer impact

N/A — no published contracts touched.

## Reviewer focus areas

- **Smoke command choice.** `mcp-server/package.json` exposes `smoke` (not `test`); the workflow calls `npm run smoke` directly. Confirm that matches your intent for the gate.
- **Path filters.** Triggers only fire for changes under `mcp-server/**` or the workflow file itself — instructions / prompts / agents edits are intentionally excluded.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)